### PR TITLE
add configuration for pi1 b+ revision 0013

### DIFF
--- a/Scripts/alarm.sh
+++ b/Scripts/alarm.sh
@@ -912,7 +912,7 @@ case "${tmp}" in
     "0002" | "0003")
         hardware='Raspberry Pi Rev 1.0'
         InitPorts;;                                    # we are on a PI so initialise the ports
-    "000d" | "000e" | "000f" | "0010")
+    "000d" | "000e" | "000f" | "0010" | "0013")
         hardware='Raspberry Pi Rev 2.0'
         InitPorts;;                                    # we are on a PI so initialise the ports
     "a01041")


### PR DESCRIPTION
i2c bus was not able to get initialized due to revision number.

this is Raspberry Pi 1 Model B+: https://www.raspberrypi.org/products/raspberry-pi-1-model-b-plus/

pi@raspberrypi:~ $ cat /proc/cpuinfo
processor    : 0
model name    : ARMv6-compatible processor rev 7 (v6l)
BogoMIPS    : 697.95
Features    : half thumb fastmult vfp edsp java tls
CPU implementer    : 0x41
CPU architecture: 7
CPU variant    : 0x0
CPU part    : 0xb76
CPU revision    : 7

Hardware    : BCM2835
Revision    : 0013
Serial        : 00000000f321a8de

before patch:
pi@raspberrypi:~ $ cat /var/log/daemon.log | grep alarm
Apr 10 21:40:28 raspberrypi alarm[212]: Starting Oddwires Alarm daemon
Apr 10 21:40:30 raspberrypi alarm[212]: 21:40:29,alarm,raspi,GPIO ports initialised for Unknown hardware

after patch:
Apr 10 22:09:39 raspberrypi alarm[9790]: Starting Oddwires Alarm daemon
Apr 10 22:09:41 raspberrypi alarm[9790]: 22:09:40,alarm,raspi,I2C Bus initialised
Apr 10 22:09:41 raspberrypi alarm[9790]: 22:09:40,alarm,raspi,GPIO ports initialised for Raspberry Pi Rev 2.0

@oddwires let me know if there is any issue.

great work you have here!